### PR TITLE
refactor(fast-data): remove beta notice from er-schema no code page

### DIFF
--- a/docs/fast_data/configuration/config_maps/erSchema.md
+++ b/docs/fast_data/configuration/config_maps/erSchema.md
@@ -174,10 +174,6 @@ Example:
 
 ## Use the No Code
 
-:::info
-This feature is still in **BETA**, so it is under active development. Pay attention using this feature.
-:::
-
 From version `10.6.0` of the Console, your project might have enabled the possibility to configure ER Schemas with the No Code feature.
 
 ![Complete View of an ER Schema](../../img/er-schema-complete-view.png)

--- a/docs/fast_data/configuration/config_maps/erSchema.md
+++ b/docs/fast_data/configuration/config_maps/erSchema.md
@@ -178,7 +178,7 @@ From version `10.6.0` of the Console, your project might have enabled the possib
 
 ![Complete View of an ER Schema](../../img/er-schema-complete-view.png)
 
-To do that, go to the _Projections_ section and click on the _ER_ Schemas_ tab: it will show a list of ER Schemas, ready to be opened and modified to your needs.
+To do that, go to the _Projections_ section and click on the _ER Schemas_ tab: it will show a list of ER Schemas, ready to be opened and modified to your needs.
 
 :::tip
 When opening the _ER Schemas_ list, you should also see the ER Schemas previously configured inside the existing Single Views.


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [X] Documentation content changes


## Description

In this MR it is removed the notice that the ER Schema with No Code UI feature is  a _beta_ version, since we are promoting it to _stable_.

In addition, a small typo has been fixed.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [X] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensible content has been committed