### PR TITLE
Fix (FDBM-63): Update DB2 Message Adapter: Specify Key in value Field for Ingestion Messages

### DIFF
--- a/docs/fast_data/configuration/realtime_updater/common.md
+++ b/docs/fast_data/configuration/realtime_updater/common.md
@@ -96,7 +96,7 @@ It's the default one, it is based on the [IBM InfoSphere Data Replication engine
 The message should include the following properties:
 - `timestamp`: a stringified integer greater than zero. This integer has to be a valid timestamp.
 - `key`: it has to be a stringified object containing the primary key of the projection, if `value` also contains the primary key of the projection this field can be an empty string.
-- `value`: it is **null** if it's a *delete* operation, otherwise it contains the data of the projection.
+- `value`: it is **null** if it's a *delete* operation, otherwise it contains the data of the projection (in this case, remember to **always** specify the object's key in the `value` field as well).
 - `offset`: it is the offset of the Kafka message.
 
 These are the only fields needed to configure correctly the message adapter. For more details and further explanations, you can read the [documentation page about the supported JSON format](https://www.ibm.com/docs/en/idr/11.4.0?topic=kcop-write-json-format-records).

--- a/docs/fast_data/configuration/realtime_updater/common.md
+++ b/docs/fast_data/configuration/realtime_updater/common.md
@@ -99,7 +99,9 @@ The message should include the following properties:
 - `value`: it is **null** if it's a *delete* operation, otherwise it contains the data of the projection.
 - `offset`: it is the offset of the Kafka message.
 
+:::info
 It is important to note that whenever the ingestion message is not a *delete* operation the `value` of the message must contain all the fields of the projection, including the primary keys also present in the `key`, so the Real Time Updater can process the message properly.
+:::
 
 These are the only fields needed to configure correctly the message adapter. For more details and further explanations, you can read the [documentation page about the supported JSON format](https://www.ibm.com/docs/en/idr/11.4.0?topic=kcop-write-json-format-records).
 

--- a/docs/fast_data/configuration/realtime_updater/common.md
+++ b/docs/fast_data/configuration/realtime_updater/common.md
@@ -96,8 +96,10 @@ It's the default one, it is based on the [IBM InfoSphere Data Replication engine
 The message should include the following properties:
 - `timestamp`: a stringified integer greater than zero. This integer has to be a valid timestamp.
 - `key`: it has to be a stringified object containing the primary key of the projection, if `value` also contains the primary key of the projection this field can be an empty string.
-- `value`: it is **null** if it's a *delete* operation, otherwise it contains the data of the projection (in this case, remember to **always** specify the object's key in the `value` field as well).
+- `value`: it is **null** if it's a *delete* operation, otherwise it contains the data of the projection.
 - `offset`: it is the offset of the Kafka message.
+
+It is important to note that when the `value` field is not a *delete* operation, the user must always specify the object's key in the `value` field as well, along with other data, to ensure proper processing by the Real-Time Updater.
 
 These are the only fields needed to configure correctly the message adapter. For more details and further explanations, you can read the [documentation page about the supported JSON format](https://www.ibm.com/docs/en/idr/11.4.0?topic=kcop-write-json-format-records).
 

--- a/docs/fast_data/configuration/realtime_updater/common.md
+++ b/docs/fast_data/configuration/realtime_updater/common.md
@@ -99,7 +99,7 @@ The message should include the following properties:
 - `value`: it is **null** if it's a *delete* operation, otherwise it contains the data of the projection.
 - `offset`: it is the offset of the Kafka message.
 
-It is important to note that when the `value` field is not a *delete* operation, the user must always specify the object's key in the `value` field as well, along with other data, to ensure proper processing by the Real-Time Updater.
+It is important to note that whenever the ingestion message is not a *delete* operation the `value` of the message must contain all the fields of the projection, including the primary keys also present in the `key`, so the Real Time Updater can process the message properly.
 
 These are the only fields needed to configure correctly the message adapter. For more details and further explanations, you can read the [documentation page about the supported JSON format](https://www.ibm.com/docs/en/idr/11.4.0?topic=kcop-write-json-format-records).
 

--- a/docs/fast_data/inputs_and_outputs.md
+++ b/docs/fast_data/inputs_and_outputs.md
@@ -68,6 +68,8 @@ Upsert operation:
     "FISCAL_CODE": "ABCDEF12B02M100O"
   },
   "value": {
+    "USER_ID": 123,
+    "FISCAL_CODE": "ABCDEF12B02M100O",
     "NAME": 456
   },
   "timestamp": "1234556789",


### PR DESCRIPTION
<!-- Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review. -->

## Description

In this page: [Inputs and Outputs | Mia-Platform Documentation](https://docs.mia-platform.eu/docs/fast_data/inputs_and_outputs)  the documentation refers to an ingestion message where the `value` property does not contain the key.

The documentation page has been updated to include also the key values in the `value` field.

This behaviour has also been properly stated on the RTU page.

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [x] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [x] No sensible content has been committed

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
