### PR TITLE
refactor(): SVTG eventStoreConfig kafka brokers are string not array of string

### DIFF
--- a/docs/fast_data/configuration/single_view_trigger_generator.md
+++ b/docs/fast_data/configuration/single_view_trigger_generator.md
@@ -105,10 +105,7 @@ At the moment you can only configure your consumer with kafka which will read `p
   "required": ["brokers", "consumerGroupId"],
   "properties": {
     "brokers": {
-      "type": "array",
-      "items": {
-        "type": "string",
-      },
+      "type": "string",
     },
     "consumerGroupId": {
       "type": "string",
@@ -217,10 +214,7 @@ With MongoDB you will save Projection Changes on the DB just like the Real Time 
   "required": ["brokers"],
   "properties": {
     "brokers": {
-      "type": "array",
-      "items": {
-        "type": "string",
-      },
+      "type": "string",
     },
     "ssl": {
       "type": "boolean",
@@ -304,7 +298,7 @@ An example of a complete configuration would be:
 {
   "consumer": {
     "kafka": {
-      "brokers": ["localhost:9092"],
+      "brokers": "localhost:9092,localhost:9093",
       "clientId": "client-id",
       "consumerGroupId": "group-id",
       "consumeFromBeginning": true,


### PR DESCRIPTION
## Description

Single View trigger generator configmap eventStoreConfig kafka's brokers are a string not an array of strings

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [x] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [x] No sensible content has been committed
