### PR TITLE
docs(bss): add bucket-folder configuration to ingestion-storer

### DIFF
--- a/docs/fast_data/bucket_storage_support/configuration/ingestion_storer.md
+++ b/docs/fast_data/bucket_storage_support/configuration/ingestion_storer.md
@@ -79,12 +79,18 @@ bss:
   topics-config:
     data-topics-mapping:
       - ingestion: <input-topic-name-1>
+        bucket-folder: <optional-custom-folder> # this field can be omitted entirely and the service would use the ingestion topic as folder name
         post-ingestion:
           - <output-topic-name-1>
       - ingestion: <input-topic-name-2>
+        bucket-folder: <optional-custom-folder> # this field can be omitted entirely and the service would use the ingestion topic as folder name
         post-ingestion:
           - <output-topic-name-2>
 ```
+
+:::info
+Associating a custom bucket folder name to an ingestion topic, via the `bucket-folder` property, allows to override the default folder where ingestion messages are stored, that corresponds to the ingestion topic name.
+:::
 
 ## File format
 


### PR DESCRIPTION
<!-- Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review. -->

## Description

Introduce new Ingestion Storer configuration parameter, `bucket-folder`, which allows to customize for each ingestion topic in which folder its messages are stored.

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [X] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [X] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensible content has been committed
