### PR TITLE
Draft: docs(CSCBM-5): Updated MongoDB version required

### DIFF
--- a/docs/self_hosted/self_hosted_requirements.md
+++ b/docs/self_hosted/self_hosted_requirements.md
@@ -136,7 +136,7 @@ The following software and hardware recommendations are for installing Mia-Platf
       <tr>
          <td><strong>NoSQL database</strong></td>
          <td><img src="/img/mongodb.ico" width="15" height="15"/> MongoDB Enterprise</td>
-         <td>&gt; 4.2</td>
+         <td>&gt; 5.0</td>
          <td>2 cores</td>
          <td>2 GB</td>
       </tr>


### PR DESCRIPTION
This PR has the goal of updating the required MongoDB version for self-hosted installations and set it to the `> 5.0` versions after discovering a bug on lower versions.