### PR TITLE
fix(fast-data): add missing steps to configure sv-patch on the svc

### DIFF
--- a/docs/fast_data/configuration/single_view_creator.md
+++ b/docs/fast_data/configuration/single_view_creator.md
@@ -414,7 +414,7 @@ This feature is supported from version `5.6.1` of the Single View Creator
 To configure a Single View Creator dedicated to [Single View Patch](/fast_data/configuration/single_views.md#single-view-patch) operations, some steps have to be followed:
 
 * Set the env var `KAFKA_PROJECTION_UPDATE_TOPICS` with the comma separated list of the `pr-update` topics corresponding to the SV-Patch Projection.
-* Configure the service to consume from Kafka (see the [Consuming from Kafka](#consuming-from-kafka))
+* Configure the service to consume from Kafka (see the [Consuming from Kafka](#consuming-from-kafka) section)
 * Set the env var `SV_TRIGGER_HANDLER_CUSTOM_CONFIG` with the path to the main file defining SV-Patches actions, for example `/home/node/app/svTriggerHandlerCustomConfig/svTriggerHandlerCustomConfig.json`
 * Create a new ConfigMap with this Runtime Mount Path: `/home/node/app/svTriggerHandlerCustomConfig`
 

--- a/docs/fast_data/configuration/single_view_creator.md
+++ b/docs/fast_data/configuration/single_view_creator.md
@@ -403,8 +403,10 @@ This feature is supported from version `5.6.1` of the Single View Creator
 To configure a Single View Creator dedicated to [Single View Patch](/fast_data/configuration/single_views.md#single-view-patch) operations, some steps have to be followed:
 
 * Set the env var `KAFKA_PROJECTION_UPDATE_TOPICS` with the comma separated list of the `pr-update` topics corresponding to the SV-Patch Projection.
+* Set the env var `PROJECTIONS_CHANGES_SOURCE` to `KAFKA` so the consumer is summoned.
+* Configure the environment variables for kafka (see the [environment variables table](#environment-variables))
 * Set the env var `SV_TRIGGER_HANDLER_CUSTOM_CONFIG` with the path to the main file defining SV-Patches actions, for example `/home/node/app/svTriggerHandlerCustomConfig/svTriggerHandlerCustomConfig.json`
-* Create a new ConfigMap with this Runtime Mount Path: `.../svTriggerHandlerCustomConfig`
+* Create a new ConfigMap with this Runtime Mount Path: `/home/node/app/svTriggerHandlerCustomConfig`
 
 This last config map is composed by a main file, `svTriggerHandlerCustomConfig.json`, which defines where to read the Patch Action for each Projection.
 

--- a/docs/fast_data/configuration/single_view_creator.md
+++ b/docs/fast_data/configuration/single_view_creator.md
@@ -414,8 +414,7 @@ This feature is supported from version `5.6.1` of the Single View Creator
 To configure a Single View Creator dedicated to [Single View Patch](/fast_data/configuration/single_views.md#single-view-patch) operations, some steps have to be followed:
 
 * Set the env var `KAFKA_PROJECTION_UPDATE_TOPICS` with the comma separated list of the `pr-update` topics corresponding to the SV-Patch Projection.
-* Set the env var `PROJECTIONS_CHANGES_SOURCE` to `KAFKA` so the consumer is summoned.
-* Configure the environment variables for kafka (see the [Consuming from Kafka](#consuming-from-kafka))
+* Configure the service to consume from Kafka (see the [Consuming from Kafka](#consuming-from-kafka))
 * Set the env var `SV_TRIGGER_HANDLER_CUSTOM_CONFIG` with the path to the main file defining SV-Patches actions, for example `/home/node/app/svTriggerHandlerCustomConfig/svTriggerHandlerCustomConfig.json`
 * Create a new ConfigMap with this Runtime Mount Path: `/home/node/app/svTriggerHandlerCustomConfig`
 

--- a/docs/fast_data/configuration/single_view_creator.md
+++ b/docs/fast_data/configuration/single_view_creator.md
@@ -150,6 +150,17 @@ service.addHook('onClose', async() => {
 
 If you do not want to use Kafka in the Single View Creator, you can just not set the environment variable *KAFKA_CLIENT_ID* or *KAFKA_BROKERS*. If one of them is missing, Kafka will not be configured by the service (requires *single-view-creator-lib* `v9.1.0` or higher)
 
+## Consuming from Kafka
+
+As you can see, the Single View Creator lets you configure what channel is used as input through the `PROJECTIONS_CHANGES_SOURCE` environment variable. The default channel is MongoDB for the [Projection Changes](/docs/fast_data/inputs_and_outputs.md#projection-changes) but this might not always be what you need. The service gives you the alternative to listen from Apache Kafka instead, this can be useful in two different cases:
+
+- You want to use the [Single View Trigger Generator](/fast_data/single_view_trigger_generator.md) to produce [`sv-trigger`](/fast_data/inputs_and_outputs.md#single-view-trigger-message) messages.
+- You want to configure the [Single View Patch](#single-view-patch) cycle which reads [`pr-update`](/fast_data/inputs_and_outputs.md#projection-update-message) messsages from the Real Time Updater.
+
+In both of the cases you have to configure all the required environment variables related to kafka. First you need to configure the `KAFKA_BROKERS` and `KAFKA_GROUP_ID`, then you probably need to configure your authentication credentials with `KAFKA_SASL_MECHANISM`, `KAFKA_SASL_USERNAME` and `KAFKA_SASL_PASSWORD`.
+
+Once this is done remember to set the `PROJECTIONS_CHANGES_SOURCE` environment variable to `KAFKA` and to check out the configuration page of the system you need to complete the necessary steps.
+
 ## Single View Key
 
 The Single View Key is the Single View Creator part which identifies the Single View document that needs to be updated as consequence of the event that the service has consumed. 
@@ -404,7 +415,7 @@ To configure a Single View Creator dedicated to [Single View Patch](/fast_data/c
 
 * Set the env var `KAFKA_PROJECTION_UPDATE_TOPICS` with the comma separated list of the `pr-update` topics corresponding to the SV-Patch Projection.
 * Set the env var `PROJECTIONS_CHANGES_SOURCE` to `KAFKA` so the consumer is summoned.
-* Configure the environment variables for kafka (see the [environment variables table](#environment-variables))
+* Configure the environment variables for kafka (see the [Consuming from Kafka](#consuming-from-kafka))
 * Set the env var `SV_TRIGGER_HANDLER_CUSTOM_CONFIG` with the path to the main file defining SV-Patches actions, for example `/home/node/app/svTriggerHandlerCustomConfig/svTriggerHandlerCustomConfig.json`
 * Create a new ConfigMap with this Runtime Mount Path: `/home/node/app/svTriggerHandlerCustomConfig`
 

--- a/docs/fast_data/configuration/single_view_creator.md
+++ b/docs/fast_data/configuration/single_view_creator.md
@@ -152,7 +152,7 @@ If you do not want to use Kafka in the Single View Creator, you can just not set
 
 ## Consuming from Kafka
 
-As you can see, the Single View Creator lets you configure what channel is used as input through the `PROJECTIONS_CHANGES_SOURCE` environment variable. The default channel is MongoDB for the [Projection Changes](/docs/fast_data/inputs_and_outputs.md#projection-changes) but this might not always be what you need. The service gives you the alternative to listen from Apache Kafka instead, this can be useful in two different cases:
+As you can see, the Single View Creator lets you configure what channel is used as input through the `PROJECTIONS_CHANGES_SOURCE` environment variable. The default channel is MongoDB for the [Projection Changes](/fast_data/inputs_and_outputs.md#projection-changes) but this might not always be what you need. The service gives you the alternative to listen from Apache Kafka instead, this can be useful in two different cases:
 
 - You want to use the [Single View Trigger Generator](/fast_data/single_view_trigger_generator.md) to produce [`sv-trigger`](/fast_data/inputs_and_outputs.md#single-view-trigger-message) messages.
 - You want to configure the [Single View Patch](#single-view-patch) cycle which reads [`pr-update`](/fast_data/inputs_and_outputs.md#projection-update-message) messsages from the Real Time Updater.

--- a/docs/fast_data/single_view_trigger_generator.md
+++ b/docs/fast_data/single_view_trigger_generator.md
@@ -13,7 +13,6 @@ from [strategies](/fast_data/the_basics.md#strategies) execution, which are curr
 
 Here below a diagram showing how the Single View Trigger Generator service integrates with Fast Data flow is provided:
 
-<!-- TODO: change the graphic (can I use excalidraw?) -->
 ![Fast data lifecycle with Single View Trigger Generator](img/svtg-fd-arch.svg)
 
 In this particular Fast Data configuration, Real-Time Updater is set to not execute strategies, but to rather emit a [Projection Update event](/fast_data/inputs_and_outputs.md#projection-update-message) (`pr-update`) for each modified projection.  
@@ -47,11 +46,11 @@ Additional details on how to configure the Real-Time Updater to produce Projecti
 The following steps are only required if you choose to [generate `sv-trigger` messages](/fast_data/configuration/single_view_trigger_generator.md#event-store-config) over Projection changes
 :::
 
-- configure the Single View Creator service to get triggered from `sv-trigger` events setting the environment variable `PROJECTIONS_CHANGES_SOURCE` to `KAFKA`
-- set environment variable `KAFKA_PROJECTION_CHANGES_TOPICS` to the topic of the event streaming platform on which the Single View Trigger Generator service will publish the `sv-trigger` events.
+- Configure the service to consume from Kafka (see the [Consuming from Kafka](/fast_data/configuration/single_view_creator.md#consuming-from-kafka) section)
+- Set environment variable `KAFKA_PROJECTION_CHANGES_TOPICS` to the topic of the event streaming platform on which the Single View Trigger Generator service will publish the `sv-trigger` events.
 In case the topic does not already exist, we recommend adopting our [naming convention](/fast_data/inputs_and_outputs.md#single-view-trigger-message) for defining the topic name.
 
-### `sv-trigger` vs. `pc`
+### Single View Trigger vs Projection Changes
 
 From version `3.0.0` the Single View Trigger Generator can also produce Projection Changes (`pc`) on MongoDB, just like the [Real Time Updater](/fast_data/configuration/realtime_updater.md#projection-changes).
 


### PR DESCRIPTION
## Description

Add missing steps on the configuration of the sv-patch in the Single View Creator

## Pull Request Type

- [X] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [X] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensible content has been committed