### PR TITLE
fix: helm chart version in RN v11.6.3

### DIFF
--- a/docs/release-notes/v11.6.3.md
+++ b/docs/release-notes/v11.6.3.md
@@ -15,4 +15,4 @@ This version addresses a bug that prevents the saving of the configuration when 
 
 ## How to update your Console
 
-For on-premise installations, please contact your Mia-Platform referent and upgrade your _Console Helm Chart_ to `v9.5.0`.
+For on-premise installations, please contact your Mia-Platform referent and upgrade your _Console Helm Chart_ to `v9.5.10`.


### PR DESCRIPTION
Correction to the helm chart referenced in `v11.6.3.md` page (supposed to be `9.5.10` instead of `9.5.0`).