### PR TITLE
docs(fast-data): introduce sv-update v2 specification in input-output page

### DIFF
--- a/docs/fast_data/inputs_and_outputs.md
+++ b/docs/fast_data/inputs_and_outputs.md
@@ -1230,8 +1230,16 @@ Example:
 
 #### Message format v2.0.0
 
+:::note
+Version `v2.0.0` of Single Update event is available starting from version `v6.1.0` of Single View Creator plugin. 
+:::
+
 This version of Single View Update event is emitted when service environment variable `SV_UPDATE_VERSION` is set to `v2.0.0`.
 In future major releases, this will become the default message format.
+
+An important feature of this new message format is the fact that it is compatible with Projection Update events. In this manner
+`sv-update` events regarding the generation of a Single View can be employed to start computing the trigger for another Single View,
+fundamentally enabling daisy-chaining the creation of two or more Single View.
 
 <details><summary>AsyncApi specification</summary>
 <p>

--- a/docs/fast_data/inputs_and_outputs.md
+++ b/docs/fast_data/inputs_and_outputs.md
@@ -1106,7 +1106,7 @@ Example: `test-tenant.PROD.restaurants-db.reviews-sv.sv-update`
 
 #### Message format v1.0.0
 
-This version of Single View Update event is emitted by default in Single View Creator version `v6`.
+This version of Single View Update event is emitted by default in Single View Creator version `v6.x.x`.
 
 <details><summary>AsyncApi specification</summary>
 <p>

--- a/docs/fast_data/inputs_and_outputs.md
+++ b/docs/fast_data/inputs_and_outputs.md
@@ -537,7 +537,10 @@ channels:
                   properties:
                     type:
                       type: string
-                      description: type of messsage (`pr-update`, `sv-update`)
+                      description: type of message
+                      enum:
+                        - pr-update
+                        - sv-update
                     version:
                       const: v2.0.0
                       description: version of the message format (v2.0.0)


### PR DESCRIPTION
<!-- Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review. -->

## Description

As described in the title, in the Fast Data input output page it has been added a new paragraph that explains the different versions of SV Update event, which is emitted by Single View Creator service.

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [X] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [X] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensitive content has been committed
