### PR TITLE
Add logr library name to ingored words for cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -342,7 +342,8 @@
     "Noto",
     "Segoe",
     "kotlinx",
-    "Dynatrace"
+    "Dynatrace",
+    "logr"
   ],
   "dictionaries": [
     "softwareTerms",


### PR DESCRIPTION
## Description

This PR will add the [logr](https://github.com/go-logr/logr/) library to the ignored words for cspell.
Is necessary because miactl is using that library and we recently updated it so its name is inside the CHANGELOG and cspell is blocking the PR for integrating the new version.

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [x] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [x] No sensitive content has been committed
