### PR TITLE
Fix github url ghr to gchr and updated docker syntax

### DIFF
--- a/docs/cli/miactl/20_setup.md
+++ b/docs/cli/miactl/20_setup.md
@@ -85,7 +85,7 @@ sudo mv /tmp/miactl /usr/local/bin
 If you want to run the cli in its environment or you want to test the cli you can use the Docker image:
 
 ```sh
-docker run ghr.io/mia-platform/miactl@0.12.1 miactl
+docker run ghcr.io/mia-platform/miactl:0.12.1 miactl
 ```
 
 ### Windows

--- a/versioned_docs/version-10.x.x/cli/miactl/20_setup.md
+++ b/versioned_docs/version-10.x.x/cli/miactl/20_setup.md
@@ -67,7 +67,7 @@ mv /tmp/miactl /usr/local/bin
 If you want to run the cli in its environment or you want to test the cli you can use the Docker image:
 
 ```sh
-docker run ghr.io/mia-platform/miactl@0.4.0 miactl
+docker run ghcr.io/mia-platform/miactl:0.4.0 miactl
 ```
 
 ## Shell Autocompletion

--- a/versioned_docs/version-11.x.x/cli/miactl/20_setup.md
+++ b/versioned_docs/version-11.x.x/cli/miactl/20_setup.md
@@ -77,7 +77,7 @@ sudo mv /tmp/miactl /usr/local/bin
 If you want to run the cli in its environment or you want to test the cli you can use the Docker image:
 
 ```sh
-docker run ghr.io/mia-platform/miactl@0.8.0 miactl
+docker run ghcr.io/mia-platform/miactl:0.8.0 miactl
 ```
 
 ### Windows


### PR DESCRIPTION
## Description

Updated link to github from `ghr.io` to `gchr.io`
## Pull Request Type

- [X] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [ ] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [ ] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensitive content has been committed