### PR TITLE
Added context to auth

### DIFF
--- a/docs/cli/miactl/30_commands.md
+++ b/docs/cli/miactl/30_commands.md
@@ -53,6 +53,7 @@ Available flags for the command:
 - `--company-id`, to set the ID of the desired Company
 - `--project-id`, to set the ID of the desired Project
 - `--environment`, to set the environment scope for the command
+- `--auth-name`, to set the name of the authentication to be used in this context
 
 ### use
 
@@ -79,7 +80,7 @@ miactl context list
 The `context auth` subcommand allows you to setup the Console Service Account you want to use to authenticate to the Console.
 
 ```sh
-miactl context auth [flags]
+miactl context auth CONTEXT [flags]
 ```
 
 Available flags:

--- a/versioned_docs/version-11.x.x/cli/miactl/30_commands.md
+++ b/versioned_docs/version-11.x.x/cli/miactl/30_commands.md
@@ -71,7 +71,7 @@ miactl context list
 The `context auth` subcommand allows you to setup the Console Service Account you want to use to authenticate to the Console.
 
 ```sh
-miactl context auth [flags]
+miactl context auth CONTEXT [flags]
 ```
 
 Available flags:


### PR DESCRIPTION
## Description
Added the context name to the `miactl auth` command, without context `miactl auth` does not work

## Pull Request Type
- [X] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [ ] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensitive content has been committed

