### PR TITLE
fix: add id/title to js-workload-configuration.md

### DIFF
--- a/docs/fast_data/runtime_management/snippets/js-workload-configuration.md
+++ b/docs/fast_data/runtime_management/snippets/js-workload-configuration.md
@@ -1,3 +1,8 @@
+---
+id: js-workload-configuration
+title: Control Plane Workloads Configuration
+---
+
 The Control Plane Configuration is managed by a dedicated Config Map.
 
 In [the Config Map section of the Design Area](/development_suite/api-console/api-design/services.md#configmaps), create a new Config Map (e.g. `control-plane-configuration`),
@@ -7,7 +12,7 @@ then create a JSON file (e.g. `config.json`) where you will write your own confi
 
 To made the service aware of the Control Plane configuration, add a new environment variable called 
 `CONTROL_PLANE_CONFIG_PATH` where you will use as value the full path of the configuration file inside
-your microservice. 
+your microservice.
 
 :::tip
 If the Control Plane is configured [with both feedback and state as gRPC channels](/fast_data/runtime_management/control_plane.mdx?control-plane-configuration=runtime#grpc),


### PR DESCRIPTION
I'm including the `id`\`title` header in the `js-workload-configuration.md` since the page it's already indexed.