### PR TITLE
Add Fluentd to cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -42,6 +42,7 @@
     "evolvability",
     "fastify",
     "fhir",
+    "Fluentd",
     "fortio",
     "furtherly",
     "gcloud",


### PR DESCRIPTION
## Description

In the Mia Care P4SaMD Node.js template documentation we reference [Fluentd](https://www.fluentd.org/), but the name is not recognized as a valid word by cspell, causing the build to fail. This PR add the `Fluentd` word to cspell.

## Pull Request Type

- [ ] Documentation content changes
- [X] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [X] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensitive content has been committed