### PR TITLE
Add SaMD to cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -117,6 +117,7 @@
     "rawp",
     "redoc",
     "sharded",
+    "SaMD",
     "traefik",
     "twilio",
     "unchecking",


### PR DESCRIPTION
## Description

SaMD (Software as Medical Device) is not recognized as a valid word by cspell, causing the build of the Mia Care Node.js template documentation to fail. This PR add the SaMD word to cspell.

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Documentation content changes
- [X] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [X] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensitive content has been committed
