### PR TITLE
fix(fast-data): add update event structure view in kafka projection updates

### DIFF
--- a/docs/fast_data/configuration/config_maps/kafka_projection_updates.mdx
+++ b/docs/fast_data/configuration/config_maps/kafka_projection_updates.mdx
@@ -120,10 +120,12 @@ While we only extracted the `after` property in the examples before, the whole o
 }
 ```
 
+:::important
 You might notice that it does not look quite like the incoming `pr-update` message you might have,
 this is because we transform the message into a unique format to represent the various versions of the message.
 So if you switch your Real-time Updater (pr-update version 1.0) for a Projection Storer (pr-update version 2.0)
 your manual strategy will still work exactly as it did before.
+:::
 
 </TabItem>
 </Tabs>

--- a/docs/fast_data/configuration/config_maps/kafka_projection_updates.mdx
+++ b/docs/fast_data/configuration/config_maps/kafka_projection_updates.mdx
@@ -66,11 +66,10 @@ This Javascript file should export a default async generator function with the f
 - `strategyContext`: object made of two properties:
   - `logger`: [Pino logger](https://github.com/pinojs/pino)
   - `dbMongo`: the configured [MongoDB Database](https://mongodb.github.io/node-mongodb-native/5.2/classes/Db.html) instance where the projections are stored
-- `updateEvent`: The [Projection Updates](/fast_data/concepts/inputs_and_outputs.md#projection-update) message.
+- `updateEvent`: The Update Event object created from the [Projection Update](/fast_data/concepts/inputs_and_outputs.md#projection-update-message) message.
 
 The function _yields_ one or more identifier retrieved from the update event. 
 
-:::tip Examples
 Here's a couple of examples example of what a custom strategy could look like:
 
 <details>
@@ -101,7 +100,30 @@ module.exports = async function* myCustomStrategy ({ logger, dbMongo }, { after 
 
 </p>
 </details>
-:::
+
+While we only extracted the `after` property in the examples before, the whole object has actually the following structure:
+
+```typescript
+{
+    operationType: string
+    operationTimestamp: string
+    before?: Document | null
+    after?: Document | null
+    primaryKeys: (string | number | symbol)[]
+    __internal__kafkaInfo: {
+      timestamp: string
+      topic: string
+      key: string
+      partition: number
+      offset: number
+  };
+}
+```
+
+You might notice that it does not look quite like the incoming `pr-update` message you might have,
+this is because we transform the message into a unique format to represent the various versions of the message.
+So if you switch your Real-time Updater (pr-update version 1.0) for a Projection Storer (pr-update version 2.0)
+your manual strategy will still work exactly as it did before.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Description

Add visualization of the update event object structure for manual strategies and the reason it has such shape

## Pull Request Type

- [X] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [X] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [X] No sensitive content has been committed

