### PR TITLE
add(data-catalog): add documentation for TLS custom certificate support on fabric BFF

### DIFF
--- a/docs/data_catalog/compatibility_matrix.md
+++ b/docs/data_catalog/compatibility_matrix.md
@@ -23,7 +23,7 @@ Please ensure that versions shown in the matrix are respected in your deployed e
 
 | Service                                                          | Version |
 | ---------------------------------------------------------------- | ------- |
-| [Fabric BFF](/data_catalog/data_catalog_fabric_bff.mdx)          | 0.2.0   |
+| [Fabric BFF](/data_catalog/data_catalog_fabric_bff.mdx)          | 0.2.1   |
 | [Open Lineage](/data_catalog/data_catalog_open_lineage.mdx)      | 0.2.0   |
 | [Job Runner](/data_catalog/data_catalog_job_runner.mdx)          | 0.1.0   |
 | [Data Catalog Frontend](/data_catalog/frontend/overview.mdx)     | 0.2.0   |

--- a/docs/data_catalog/compatibility_matrix.md
+++ b/docs/data_catalog/compatibility_matrix.md
@@ -24,7 +24,7 @@ Please ensure that versions shown in the matrix are respected in your deployed e
 | Service                                                          | Version |
 | ---------------------------------------------------------------- | ------- |
 | [Fabric BFF](/data_catalog/data_catalog_fabric_bff.mdx)          | 0.2.1   |
-| [Open Lineage](/data_catalog/data_catalog_open_lineage.mdx)      | 0.2.0   |
+| [Open Lineage](/data_catalog/data_catalog_open_lineage.mdx)      | 0.2.1   |
 | [Job Runner](/data_catalog/data_catalog_job_runner.mdx)          | 0.1.0   |
-| [Data Catalog Frontend](/data_catalog/frontend/overview.mdx)     | 0.2.0   |
+| [Data Catalog Frontend](/data_catalog/frontend/overview.mdx)     | 0.2.1   |
 | [Fabric Admin](/data_catalog/database_setup.mdx)                 | 0.2.0   |

--- a/docs/data_catalog/compatibility_matrix.md
+++ b/docs/data_catalog/compatibility_matrix.md
@@ -24,7 +24,7 @@ Please ensure that versions shown in the matrix are respected in your deployed e
 | Service                                                          | Version |
 | ---------------------------------------------------------------- | ------- |
 | [Fabric BFF](/data_catalog/data_catalog_fabric_bff.mdx)          | 0.2.1   |
-| [Open Lineage](/data_catalog/data_catalog_open_lineage.mdx)      | 0.2.1   |
+| [Open Lineage](/data_catalog/data_catalog_open_lineage.mdx)      | 0.2.2   |
 | [Job Runner](/data_catalog/data_catalog_job_runner.mdx)          | 0.1.0   |
 | [Data Catalog Frontend](/data_catalog/frontend/overview.mdx)     | 0.2.1   |
 | [Fabric Admin](/data_catalog/database_setup.mdx)                 | 0.2.0   |

--- a/docs/data_catalog/data_catalog_fabric_bff.mdx
+++ b/docs/data_catalog/data_catalog_fabric_bff.mdx
@@ -131,6 +131,10 @@ The following properties support [secret resolution](/fast_data/configuration/se
 - `console.auth.credentials.privateKey`
 :::
 
+A custom x509 certificate can be added to the default root keychain of certificates for any client/reversed-proxy reached by Fabric BFF.
+Custom certificate must be mounted on local file system of Fabric BFF and referenced in the configuration at 'settings.tls.certificate'
+as a [secret](/fast_data/configuration/secrets_resolution.md).
+
 #### Persistence Layer
 
 

--- a/docs/fast_data/faq/fast_data_versioning.md
+++ b/docs/fast_data/faq/fast_data_versioning.md
@@ -47,7 +47,7 @@ is `v7.5.4`
 
 | Real-Time-Updater | Single View Trigger Generator | Single View Creator |
 |:-----------------:|:-----------------------------:|:-------------------:|
-|       7.9.0       |             3.3.2             |        6.7.1        |
+|       7.9.1       |             3.3.3             |        6.7.2        |
 
 ### Projection Storer Support
 
@@ -66,7 +66,7 @@ the final aggregated Single View.
 
 | Projection Storer | Single View Trigger Generator | Single View Creator |
 |:-----------------:|:-----------------------------:|:-------------------:|
-|       1.3.4       |             3.3.2             |        6.7.1        |
+|       1.3.5       |             3.3.3             |        6.7.2        |
 
 
 ### Runtime Management Support

--- a/docs/fast_data/runtime_management/compatibility_matrix.md
+++ b/docs/fast_data/runtime_management/compatibility_matrix.md
@@ -31,7 +31,7 @@ Please ensure that your services respects the following matrix.
 
 | Service                                                                            | Version |
 |------------------------------------------------------------------------------------|---------|
-| [Fabric BFF](/fast_data/runtime_management/control_plane_fabric_bff.mdx)           | 0.2.0   |
+| [Fabric BFF](/fast_data/runtime_management/control_plane_fabric_bff.mdx)           | 0.2.1   |
 | [Control Plane](/fast_data/runtime_management/control_plane.mdx)                   | 0.1.1   |
 | [Control Plane Operator](/fast_data/runtime_management/control_plane_operator.mdx) | 0.1.1   |
 | [Control Plane Frontend](/fast_data/runtime_management/control_plane_frontend.mdx) | 0.4.1   |

--- a/docs/fast_data/runtime_management/compatibility_matrix.md
+++ b/docs/fast_data/runtime_management/compatibility_matrix.md
@@ -34,5 +34,5 @@ Please ensure that your services respects the following matrix.
 | [Fabric BFF](/fast_data/runtime_management/control_plane_fabric_bff.mdx)           | 0.2.1   |
 | [Control Plane](/fast_data/runtime_management/control_plane.mdx)                   | 0.1.1   |
 | [Control Plane Operator](/fast_data/runtime_management/control_plane_operator.mdx) | 0.1.1   |
-| [Control Plane Frontend](/fast_data/runtime_management/control_plane_frontend.mdx) | 0.4.1   |
+| [Control Plane Frontend](/fast_data/runtime_management/control_plane_frontend.mdx) | 0.4.2   |
 | [Fabric Admin](/fast_data/runtime_management/database_setup.mdx)                   | 0.2.0   |

--- a/static/schemas/data_fabric/data-catalog-fabric-bff.config.schema.json
+++ b/static/schemas/data_fabric/data-catalog-fabric-bff.config.schema.json
@@ -17,6 +17,16 @@
         }
       ]
     },
+    "controlPlane": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ControlPlaneSettings"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "jobRunner": {
       "anyOf": [
         {
@@ -44,59 +54,6 @@
       "$ref": "#/definitions/Settings"
     }
   },
-  "examples": [
-    {
-      "console": {
-        "rest": {
-          "target": {
-            "type": "env",
-            "key": "CONSOLE_BASE_URL"
-          },
-          "auth": {
-            "type": "oauth2",
-            "flow": "client_credentials",
-            "tokenEndpoint": "/api/m2m/oauth/token",
-            "credentials": {
-              "clientId": {
-                "type": "file",
-                "path": "/run/secrets/data-fabric/fabric-bff.ini",
-                "key": "FABRIC_CLIENT_ID"
-              },
-              "clientSecret": {
-                "type": "file",
-                "path": "/run/secrets/data-fabric/fabric-bff.ini",
-                "key": "FABRIC_M2M_CLIENT_SECRET"
-              }
-            }
-          }
-        }
-      },
-      "openLineage": {
-        "rest": {
-          "target": "http://open-lineage"
-        },
-        "grpc": {
-          "target": "http://open-lineage:50051"
-        }
-      },
-      "jobRunner": {
-        "grpc": {
-          "target": "http://job-runner:50051"
-        }
-      },
-      "persistence": {
-        "type": "mongodb",
-        "configuration": {
-          "url": {
-            "type": "file",
-            "path": "/run/secrets/data-fabric/fabric-bff.ini",
-            "key": "MONGODB_URL"
-          },
-          "database": "data-fabric-db"
-        }
-      }
-    }
-  ],
   "definitions": {
     "AuthContext": {
       "oneOf": [
@@ -182,6 +139,32 @@
         }
       }
     },
+    "ControlPlaneSettings": {
+      "description": "Settings describing the connections with Control Plane service",
+      "type": "object",
+      "required": [
+        "grpc",
+        "rest"
+      ],
+      "properties": {
+        "grpc": {
+          "description": "Configuration related to the inter-service communication with Control Plane service",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GrpcProxy"
+            }
+          ]
+        },
+        "rest": {
+          "description": "Configuration related to the exposed REST APIs that are proxied",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RestProxy"
+            }
+          ]
+        }
+      }
+    },
     "GrpcProxy": {
       "description": "Configuration regarding the GRPC services called by the BFF",
       "type": "object",
@@ -222,7 +205,7 @@
       ],
       "properties": {
         "grpc": {
-          "description": "Configuration related to the gRPC service of JobRunner",
+          "description": "Configuration related to the bulk actions Data Catalog service",
           "allOf": [
             {
               "$ref": "#/definitions/GrpcProxy"
@@ -340,6 +323,32 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "tls": {
+          "description": "Client TLS proxy settings",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "TlsOptions": {
+      "type": "object",
+      "properties": {
+        "certificate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/secret"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       }


### PR DESCRIPTION
## Description

Version 0.2.1 of Fabric BFF supports custom x509 certificates when reaching upstream services.
- Application config schema updated
- Compatibility matrix + latest versions updated

## Pull Request Type

- [x] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [x] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [x] No sensitive content has been committed
