### PR TITLE
Fix danger in replicas documentation

### DIFF
--- a/docs/development_suite/api-console/api-design/replicas.md
+++ b/docs/development_suite/api-console/api-design/replicas.md
@@ -13,9 +13,8 @@ Based on your release pipeline, the `ENABLE_HPA` environment variable could need
 :::
 
 :::danger
-The replicas configured will not work properly if the [static replicas](/development_suite/api-console/api-design/services.md#microservice-configuration) is set to 0.
-
-Setting both static replicas and HPA Replicas may lead to undefined behaviors
+When the HPA is not active, the static replicas setting will determine the number of replicas. 
+If the HPA is active, the [static replicas](/development_suite/api-console/api-design/services.md#microservice-configuration) setting will serve as a baseline, but it must be configured with a non-zero value to ensure a minimum number of replicas.
 :::
 
 ## Configure Replicas


### PR DESCRIPTION
## Description

Description
This pull request aims to improve the clarity of the documentation regarding managing static replicas and horizontal pod autoscalers (HPA). The current documentation might be confusing for users trying to understand the difference between these two approaches to scaling deployments.

## Pull Request Type
- [x] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [ ] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [ ] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [ ] No sensitive content has been committed
