### PR TITLE
fix(sofware caralog): miactl commands

### DIFF
--- a/docs/console/tutorials/visualize-infrastructure-project-components-runtime-data-in-console.md
+++ b/docs/console/tutorials/visualize-infrastructure-project-components-runtime-data-in-console.md
@@ -58,7 +58,7 @@ runtime-data:
     - miactl context auth ci-auth --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET"
     - miactl context set console --endpoint $CONSOLE --company-id $COMPANY_ID --auth-name ci-auth
     - miactl context use console
-    - miactl marketplace apply --company-id=$COMPANY_ID -f runtime_manifest.json
+    - miactl catalog apply --company-id=$COMPANY_ID -f runtime_manifest.json
 ```
 
 <details>

--- a/docs/software-catalog/items-management/miactl.md
+++ b/docs/software-catalog/items-management/miactl.md
@@ -4,7 +4,7 @@ title: miactl
 sidebar_label: miactl
 ---
 
-One of the possible ways to interact with the Catalog is through [`miactl`](/cli/miactl/10_overview.md), the Mia-Platform Command Line Interface. 
+One of the possible ways to interact with the Catalog is through [`miactl`](/cli/miactl/10_overview.md), the Mia-Platform Command Line Interface.
 
 :::tip
 Before getting started, make sure you have completed the [setup guide](/cli/miactl/20_setup.md).
@@ -75,7 +75,7 @@ The idea behind the automation of the managing process is to leverage a CI/CD to
 
 Any CI/CD tool will do the trick, but in this example we will focus on a Gitlab pipeline.
 
-First of all, you need to create a **service account** on the Console, using, for example, the [Client Secret Basic authentication](/development_suite/identity-and-access-management/manage-service-accounts.md#adding-a-service-account). 
+First of all, you need to create a **service account** on the Console, using, for example, the [Client Secret Basic authentication](/development_suite/identity-and-access-management/manage-service-accounts.md#adding-a-service-account).
 
 With the account in place, create a `CLIENT_ID` and a `CLIENT_SECRET` [Gitlab CI/CD Variable](https://docs.gitlab.com/ee/ci/variables/) in your project and set the respective `client-id` and `client-secret` values you obtained during the setup of the service account.
 
@@ -111,7 +111,7 @@ apply-catalog:
     - miactl context auth new-auth --client-id $CLIENT_ID --client-secret $CLIENT_SECRET
     - miactl context set new-context --company-id $COMPANY_ID --endpoint $CONSOLE_ENDPOINT --auth-name new-auth
     - miactl context use new-context
-    - miactl marketplace apply -f ./items
+    - miactl catalog apply -f ./items
 
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -139,4 +139,4 @@ In this way, even users without the permission to manage the Catalog directly ca
 
 When deleting an item or an item's version from the Catalog, keep in mind that you need to work both on the repository and on the Catalog itself, since a declarative approach usually works only in addition (i.e., deleting a manifest from the repository will not remove the item from the Catalog).
 
-Therefore, remove the manifest from Git and use the `miactl marketplace delete` command to clean the Catalog.
+Therefore, remove the manifest from Git and use the `miactl catalog delete` command to clean the Catalog.

--- a/docs/software-catalog/tutorials/service-template-integrated-with-jenkins.md
+++ b/docs/software-catalog/tutorials/service-template-integrated-with-jenkins.md
@@ -20,7 +20,7 @@ Marketplace service templates can be configured to be built using Jenkins, this 
 We are going to create the service template in the Marketplace using `miactl` and link a git repository containing the Jenkins pipeline template:
 
 - Create the marketplace resource object and save it in `jenkins-service-template.yaml`
- 
+
   ```yaml
   tenantId: <TENANT_ID>
   type: template
@@ -76,7 +76,7 @@ We are going to create the service template in the Marketplace using `miactl` an
 - Apply the resource using `miactl`
 
   ```sh
-  miactl marketplace apply -f jenkins-service-template.yaml
+  miactl catalog apply -f jenkins-service-template.yaml
   ```
 
 - In the linked repository create the Jenkins pipeline template at `services/node.xml`, this will instruct Jenkins to build the service when a new commit is pushed to the repository and run the
@@ -199,7 +199,7 @@ pipeline as defined in the linked `Jenkinsfile`. This template will be interpola
   - `mia_template_service_name_placeholder` name of the service, as specified in the Project
   - `mia_template_project_id_placeholder` the identifier of the Project
   - `mia_template_image_name_placeholder` the image name of the service, as specified in the Project
-  - `%CUSTOM_PLUGIN_PROJECT_NAME%` name of the Project 
+  - `%CUSTOM_PLUGIN_PROJECT_NAME%` name of the Project
   - `%CUSTOM_PLUGIN_SERVICE_DESCRIPTION%` service description
   - `%CUSTOM_PLUGIN_CREATOR_USERNAME%` username of the user who created the service
   - `%CUSTOM_PLUGIN_PROJECT_FULL_PATH%` the full path of the Project in the Git provider
@@ -207,7 +207,7 @@ pipeline as defined in the linked `Jenkinsfile`. This template will be interpola
   - `%GIT_PROVIDER_GROUP%` the group of service repository
   - `%GIT_PROVIDER_PROJECT%` the name of the service repository
   - `%CUSTOM_PLUGIN_PROJECT_GIT_PATH%` the full path of the service repository
-  - `%NEXUS_HOSTNAME%` registry hostname 
+  - `%NEXUS_HOSTNAME%` registry hostname
   - `%SECRET_TOKEN%`secret token used to trigger the pipeline
 
 - create the build pipeline definition `Jenkinsfile`

--- a/docs/software-catalog/tutorials/software-catalog.md
+++ b/docs/software-catalog/tutorials/software-catalog.md
@@ -232,7 +232,7 @@ First of all, download and save the latest version of the item configuration:
 
 ```bash
 
-> miactl catalog get --item-id ITEM-ID --version VERSION > myAwesomeService.json
+> miactl catalog get --item-id ITEM_ID --version VERSION > myAwesomeService.json
 
 ```
 

--- a/docs/software-catalog/tutorials/software-catalog.md
+++ b/docs/software-catalog/tutorials/software-catalog.md
@@ -57,7 +57,7 @@ For a detailed explanation of the required metadata please refere to [this guide
    5. `Name` that is the name of the service
    6. `Description`
    7. `Repository Url` which is the url to the source code of the service
-   8. `Docker Image` 
+   8. `Docker Image`
 
 :::caution
 The `Asstes` object have a different spec based on the `Item Type` the exaple provided in this guide is related to the components of item `plugin`
@@ -122,7 +122,7 @@ For reference this is the `Assets` object configuration for an hypothetical plug
 ```
 
 :::caution
-The `componentId` and `name` fields must be equal. 
+The `componentId` and `name` fields must be equal.
 :::
 
 1. **Complete the process** – Follow the on-screen instructions, then save and submit the item to add it to the Catalog.
@@ -136,7 +136,7 @@ Using `miactl` requires setting up the CLI beforehand. For more details, refer t
 :::
 
 :::info
-For testing purpose you can use your own account to create context and log-in the Mia-Platform Console using miactl. 
+For testing purpose you can use your own account to create context and log-in the Mia-Platform Console using miactl.
 For production purpose the use of a `Service Account` with the `Company Owner` permission is recommended. To know more about service accounts follow this [documentation page](/development_suite/identity-and-access-management/manage-service-accounts.md).
 :::
 
@@ -199,7 +199,7 @@ Once the `manifest.json` is ready, the following commands are needed to release 
 > miactl context auth miactl-bot --client-id $CLIENT_ID --client-secret $CLIENT_SECRET
 > miactl context set my-context --company-id $COMPANY_ID --endpoint $CONSOLE_URL --auth-name miactl-bot
 > miactl context use my-context
-> miactl marketplace apply -f ./manifest.json
+> miactl catalog apply -f ./manifest.json
 
 ```
 
@@ -232,17 +232,17 @@ First of all, download and save the latest version of the item configuration:
 
 ```bash
 
-> miactl marketplace get ITEM_ID > myAwesomeService.json
+> miactl catalog get --item-id ITEM-ID --version VERSION > myAwesomeService.json
 
 ```
 
-If you don't know the item id, use the `miactl marketplace list` command to list all the Catalog items.
+If you don't know the item id and/or the version, use the `miactl catalog list` command to list all the Catalog items.
 
 Once you have the manifest, modify the fields you need and the publish the new version using the following command:
 
 ```bash
 
-> miactl marketplace apply -f myAwesomeService.json
+> miactl catalog apply -f myAwesomeService.json
 
 ```
 


### PR DESCRIPTION
## Description

Changed `miactl marketplace` commands in software catalog doc and tutorial to the new `miactl catalog` command

## Pull Request Type

- [x] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [ ] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [x] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [x] No sensitive content has been committed
