### PR TITLE
Update the Kustomize HA Use Case to better handle Replicas distribution with label pod-template-hash

### DIFF
--- a/docs/products/console/project-configuration/kustomize-your-configurations/kustomize-use-cases.md
+++ b/docs/products/console/project-configuration/kustomize-your-configurations/kustomize-use-cases.md
@@ -3,6 +3,7 @@ id: kustomize-use-cases
 title: Kustomize Use Cases
 sidebar_label: Kustomize Use Cases
 ---
+
 In this page you can see examples of how you can use Kustomize in order to manage some use cases.
 
 ### Patch replicas
@@ -22,7 +23,7 @@ spec:
   template:
     spec:
       containers:
-      - image: hello-world:latest
+        - image: hello-world:latest
 ```
 
 The base configuration sets the number of replicas to 1. Now, let's define an overlay for the production environment that changes the number of replicas from 1 to 2.
@@ -46,17 +47,19 @@ Sometimes you could need to patch keys containing a `/` character.
 The `/` character is often used (e.g. for inline operations) by Kustomize as separator, consequently you need to replace it with the `~1` value.
 
 For example, if you want to add the `app.kubernetes.io/component` label to one or more manifests, you should escape the slash as following:
+
 ```yaml
 - patch: |-
-      - op: replace
-        path: /metadata/labels/app.kubernetes.io~1component
-        value: monitoring
+    - op: replace
+      path: /metadata/labels/app.kubernetes.io~1component
+      value: monitoring
 ```
+
 :::
 
 ### Patch all deployments
 
-In addition, Kustomize allows you to specify a list of targets in the  `kustomization.yaml` files included in overlays. This feature allows applying patches to multiple resources at once.
+In addition, Kustomize allows you to specify a list of targets in the `kustomization.yaml` files included in overlays. This feature allows applying patches to multiple resources at once.
 
 The snippet below includes all the available targets:
 
@@ -88,7 +91,7 @@ spec:
   template:
     spec:
       containers:
-      - image: hello-world:latest
+        - image: hello-world:latest
 ---
 # file: ./configuration/goodbyeworld.deployment.yaml
 apiVersion: apps/v1
@@ -100,7 +103,7 @@ spec:
   template:
     spec:
       containers:
-      - image: goodbye-world:latest
+        - image: goodbye-world:latest
 ```
 
 First off, you need to create the patch containing the sidecar container specification in the environment of interest (e.g. development).
@@ -118,8 +121,8 @@ spec:
         - name: istio-proxy
           image: docker.io/istio/proxyv2
           args:
-          - proxy
-          - sidecar
+            - proxy
+            - sidecar
 ```
 
 Then, to apply the patch to all your Deployments, you have to manually edit the `kustomization.yaml` file in the selected overlay directory. For instance, if you want to inject the sidecar in the development environment, the corresponding `kustomization.yaml` would look like this:
@@ -127,12 +130,12 @@ Then, to apply the patch to all your Deployments, you have to manually edit the 
 ```yaml
 # file: ./overlays/development/kustomization.yaml
 resources:
-- ../../configuration
+  - ../../configuration
 
 patches:
-- path: sidecar.patch.yaml
-  target:
-    kind: Deployment
+  - path: sidecar.patch.yaml
+    target:
+      kind: Deployment
 ```
 
 :::info
@@ -147,14 +150,14 @@ For example, you can patch only deployments with a specific label or annotation:
 ```yaml
 # file: ./overlays/development/kustomization.yaml
 resources:
-- ../../configuration
+  - ../../configuration
 
 patches:
-- path: sidecar.patch.yaml
-  target:
-    kind: Deployment
-    labelSelector: myLabel=labelValue,otherLabel=otherValue
-    annotationSelector: myAnnotation=annotationValue,otherAnnotation=otherValue
+  - path: sidecar.patch.yaml
+    target:
+      kind: Deployment
+      labelSelector: myLabel=labelValue,otherLabel=otherValue
+      annotationSelector: myAnnotation=annotationValue,otherAnnotation=otherValue
 ```
 
 With the example above, the `istio-proxy` container will be added to deployments with **all the specified labels and annotations**.
@@ -166,16 +169,17 @@ You can apply labels to microservices inside the Design section of the Mia-Platf
 ### Enable **High Availability** for business critical microservices
 
 Sometimes you need to be sure about the availability of few business critical microservices due to different reasons:
-* kubernetes cluster update;
-* start of a new business campaign;
-* ...
 
-In order to do that you probably want some microservice in *High Availability*.
+- kubernetes cluster update;
+- start of a new business campaign;
+- any other business.
+
+In order to do so you probably want some microservice configured for _High Availability_.
 :::info
-The _High Availability_ is a characteristic of a system, an application, a service, that guarantee operability without intervention, even if there are problems on an instance of it.
+The _High Availability_ is a characteristic of a system, an application, or a service, that guarantees operability without intervention, even if there are problems on an instance of it.
 :::
 
-Using *Kustomize* and the *Mia-Platform Console* you can add advanced configurations to your business critical microservices.
+Using _Kustomize_ and the _Mia-Platform Console_ you can add advanced configurations to your business critical microservices.
 
 :::warning
 The following **is a basic example** that allows you to replicate and distribute replicas of services on different nodes of your cluster.
@@ -184,14 +188,17 @@ Remember to always check your specific needs and customize the patch files based
 :::
 
 In this example is showed how to guarantee that, on each business critical microservice, you have:
-* 3 up and running replicas;
-* replicas distributed through different nodes of the cluster.
 
-Of course we need to focus just on business critical services, so we will use a specific label to identify the right targets.
+- 3 up and running replicas;
+- replicas distributed through different nodes of the cluster.
+
+We should focus just on business critical services, so we will use a specific label to identify the right targets.
 The label is:
-> **highAvailability**: *true*
 
-Let's assume we have this following deployments:
+> **highAvailability**: _true_
+
+Let's assume we have the following deployments:
+
 ```yml
 # file: ./configuration/helloworld.deployment.yaml
 apiVersion: apps/v1
@@ -205,7 +212,7 @@ spec:
   template:
     spec:
       containers:
-      - image: hello-world:latest
+        - image: hello-world:latest
 ---
 # file: ./configuration/goodbyeworld.deployment.yaml
 apiVersion: apps/v1
@@ -219,29 +226,13 @@ spec:
   template:
     spec:
       containers:
-      - image: goodbye-world:latest
+        - image: goodbye-world:latest
 ```
 
-We expect to have the High Availability enabled on the `hello-world` service only, since the `goodbye-world` one doesn't have `highAvailability: true`.
-To do that we can use the following Kustomize configurations:
-```yml
-# file: ./overlays/PROD/high-availability.patch.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: not-important
-spec:
-  replicas: 3
-  template:
-    spec:
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              highAvailability: "true"
+We expect to have the High Availability enabled on the `hello-world` service only, since the `goodbye-world` one doesn't have the `highAvailability: true` label.
+To do so, we can use the following Kustomize configurations:
 
+```yml
 # file: ./overlays/PROD/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -249,18 +240,35 @@ resources:
   - ../../configuration
 
 patches:
-- path: high-availability.patch.yaml
-  target:
-    kind: Deployment
-    labelSelector: highAvailability=true
+  - target:
+      kind: Deployment
+      labelSelector: "highAvailability=true"
+    patch: |-
+      - op: add
+        path: /spec/template/spec/topologySpreadConstraints
+        value:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                highAvailability: "true"
+            matchLabelKeys:
+              - pod-template-hash
+      - op: replace
+        path: /spec/replicas
+        value: 3
 ```
 
-How can the files above let use reach our goal?
-* **replicas: 3** &rarr; in this way, all services that match the condition will have 3 static replicas (of course you can increase this number if you want more replicas);
-* **topologySpreadConstraints** &rarr; property that allows to describe the topology of your infrastructure and how the pods are distributed;
-  * **maxSkew** &rarr; the degree to which Pods may be unevenly distributed. We set it to **1**, to have at most 1 different replica among nodes;
-  * **topologyKey** &rarr; the topology key to be used for the pods distribution. We set it to **kubernetes.io/hostname**, that contains the k8s node;
-  * **whenUnsatisfiable** &rarr; what k8s must do if the condition is not satisfiable. Setting it to **ScheduleAnyway** ensure us the replica will be scheduled anyway.
+The configuration shown above will edit the manifest of all the deployment workloads having the label `highAvailability: true` in two different ways:
+
+- it will replace the value of the **replicas** field to **3**;
+- it will add the **topologySpreadConstraints** property, that allows to describe the topology of your infrastructure and how the pods are distributed:
+  - **maxSkew** &rarr; the degree to which Pods may be unevenly distributed. We set it to **1**, to have at most 1 different replica among nodes;
+  - **topologyKey** &rarr; the topology key to be used for the pods distribution. We set it to **kubernetes.io/hostname**, that represents the k8s node;
+  - **whenUnsatisfiable** &rarr; what the k8s scheduler must do if the condition is not satisfiable. Setting it to **ScheduleAnyway** ensure us the replica will be scheduled anyway.
+  - **labelSelector** &rarr; enforce the topologySpreadConstraint property to spread replicas having this label
+  - **matchLabelKeys** &rarr; this label will ensure the user that replicas from the same deployment will be spread across different nodes. The label used, **pod-template-hash**, is a special one that will be added automatically by Kubernetes when applying the resource and will have the same value for every replica from the same deployment.
 
 :::tip
 The **topologySpreadConstraints** is a very rich and powerful property.
@@ -269,9 +277,13 @@ It allows you to control how Pods are spread across your cluster among failure-d
 Look at the [k8s official documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for more.
 :::
 
-The result, by deploying this **after** [**decorating your business critical services**](/products/console/api-console/api-design/services.md#labels-configuration) with the *highAvailability: true* label, is having 3 replicas of the services, spread across your cluster nodes.
+:::info
+The **pod-template-hash** label is available starting from Kubernetes v1.27, you can find more about it in the [Kubernetes official documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template-hash-label)
+:::
+
+The result, by deploying this **after** [**decorating your business critical services**](/products/console/api-console/api-design/services.md#labels-configuration) with the _highAvailability: true_ label, is having 3 replicas of the services, spread across your cluster nodes.
 
 :::warning
-If you have the [Horizontal Pod Autoscaler enabled](/products/console/api-console/api-design/replicas.md) on some microservices, the value of the *static replicas* you set will not work.
+If you have the [Horizontal Pod Autoscaler enabled](/products/console/api-console/api-design/replicas.md) on some microservices, the value of the _static replicas_ you set will not work.
 To fix that be sure to adjust the `minReplicas` value of the HPA through the Console page, otherwise some service could have just one replica &rarr; not High Availability.
 :::


### PR DESCRIPTION
<!-- Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review. -->

## Description

<!-- Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is it important? -->

I've updated the section related to the [Kustomize High Availability Use Case](https://docs.mia-platform.eu/docs/products/console/project-configuration/kustomize-your-configurations/kustomize-use-cases#enable-high-availability-for-business-critical-microservices) since the previous version described a configuration that doesn't give the user the certainty to have replicas distributed into multiple nodes in the case many microservices were configured to have the `highAvailability` label set to _true_ (as per the example).
The revisited Use Case now uses the `matchLabelKeys` **pod-template-hash** to better handle this use case. This is a newer label (released in K8s v1.27, [here some info](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template-hash-label)) that Kubernetes automatically adds to the Pod manifests and has the same value for every replica of the ReplicaSet of a deployment.

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Documentation content changes
- [ ] Bugfix / Missing Redirects
- [ ] Docusaurus site code changes

## PR Checklist

- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#how-to-submit-a-pr)
- [x] All tests of Lint, cspell and check-content pass. ([How to launch them?](../blob/main/CONTRIBUTING.md#content-checks))
- [x] No sensitive content has been committed

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
